### PR TITLE
Add way to make unsecured HTTP requests

### DIFF
--- a/Sources/BachandNetworking/HTTPResponse.swift
+++ b/Sources/BachandNetworking/HTTPResponse.swift
@@ -32,35 +32,58 @@ enum HTTPResponseError {
   enum Code: Int {
     /// Apple Foundation framework returns a response that is not of type `HTTPURLResponse`.
     case responseNotHTTP = 100
-    /// Developer specified a URL that does not have the HTTP scheme.
+    /// Developer specified a URL that does not have the "https" scheme.
     case schemeNotSecure = 101
+    /// Developer specified a URL that does not have a "http" or "https" scheme.
+    case schemeNotHTTPBased = 102
   }
 }
 
-/// Creates a data task publisher for a HTTPS request.
+/// Creates a data task publisher for a URL where the data is retrievable over HTTP. The output of that publisher is mapped to a
+/// `HTTPResponse`.
 ///
-/// - Parameter urlRequest: The request to make.
+/// - Parameter url: The URL to which we should make a request.
 /// - Parameter session: The session that will make the request.
 ///
 /// - Returns: A type-erased publisher.
 ///
-/// - Throws: An error if the URL has any scheme other than "http". The error will have the domain "HTTPResponse" and the code
+/// - Throws: An error if the URL has any scheme other than "https". The error will have the domain "HTTPResponse" and the code
 /// 101. The error is of type `NSError`.
-public func makeSecureDataTaskPublisher(
+public func makeSecureHTTPResponsePublisher(
   for url: URL,
   on urlSession: URLSession = .shared)
   throws
   -> AnyPublisher<HTTPResponse, URLError>
 {
   guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotSecure) }
+  return try makeHTTPResponsePublisher(for: url, on: urlSession)
+}
+
+/// Creates a data task publisher for a URL where the data is retrievable over HTTP or HTTPS. The output of that publisher is mapped to
+/// a `HTTPResponse`.
+///
+/// - Parameter url: The URL to which we should make a request.
+/// - Parameter session: The session that will make the request.
+///
+/// - Returns: A type-erased publisher.
+///
+/// - Throws: An error if the URL has any scheme other than "http" or "https". The error will have the domain "HTTPResponse" and
+/// the code 102. The error is of type `NSError`.
+public func makeHTTPResponsePublisher(
+  for url: URL,
+  on urlSession: URLSession = .shared)
+  throws
+  -> AnyPublisher<HTTPResponse, URLError>
+{
+  guard let scheme = url.scheme, ["http", "https"].contains(scheme) else {
+    throw makeError(code: .schemeNotHTTPBased)
+  }
 
   let publisher = urlSession.dataTaskPublisher(for: url)
   // Force unwrapping because the scheme is HTTPS. Apple documentation says that you will always
   // give back a `HTTPURLResponse` if you issue a request to a URL with a HTTP scheme.
   return publisher.map { try! HTTPResponse(data: $0, urlResponse: $1) }.eraseToAnyPublisher()
 }
-
-// TODO: Add `makeUnsecuredDataTaskPublisher(...)` for HTTP requests.
 
 private func makeError(code: HTTPResponseError.Code) -> Error {
   NSError(domain: HTTPResponseError.errorDomain, code: code.rawValue)

--- a/Sources/BachandNetworking/HTTPResponse.swift
+++ b/Sources/BachandNetworking/HTTPResponse.swift
@@ -33,7 +33,7 @@ enum HTTPResponseError {
     /// Apple Foundation framework returns a response that is not of type `HTTPURLResponse`.
     case responseNotHTTP = 100
     /// Developer specified a URL that does not have the "https" scheme.
-    case schemeNotSecure = 101
+    case schemeNotHTTPS = 101
     /// Developer specified a URL that does not have a "http" or "https" scheme.
     case schemeNotHTTPBased = 102
   }
@@ -55,7 +55,7 @@ public func makeSecureHTTPResponsePublisher(
   throws
   -> AnyPublisher<HTTPResponse, URLError>
 {
-  guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotSecure) }
+  guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
   return try makeHTTPResponsePublisher(for: url, on: urlSession)
 }
 

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -30,7 +30,15 @@ final class HTTPResponseTests: XCTestCase {
 
 final class HTTPResponseFactoryTests: XCTestCase {
 
-  func test_schemeIsNotSecure_throwsError() throws {
+  func test_makeSecureHTTPResponsePublisher_schemeIsHTTPS_doesNotThrowsError() throws {
+    let url = URL(string: "https://apple.com")
+    XCTAssertNotNil(try url.flatMap { url in
+      XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: url))
+      return url
+    })
+  }
+
+  func test_makeSecureHTTPResponsePublisher_schemeIsHTTP_throwsError() throws {
     let url = URL(string: "http://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       let errorHandler: (Error) -> Void = {
@@ -38,8 +46,54 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotSecure.rawValue)
       }
       XCTAssertThrowsError(
-        try makeSecureDataTaskPublisher(for: url),
+        try makeSecureHTTPResponsePublisher(for: url),
         "Error has code for .schemeNotSecure",
+        errorHandler)
+      return url
+    })
+  }
+
+  func test_makeSecureHTTPResponsePublisher_schemeIsFTP_throwsError() throws {
+    let url = URL(string: "ftp://apple.com")
+    XCTAssertNotNil(try url.flatMap { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotSecure.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeSecureHTTPResponsePublisher(for: url),
+        "Error has code for .schemeNotSecure",
+        errorHandler)
+      return url
+    })
+  }
+
+  func test_makeHTTPResponsePublisher_schemeIsHTTP_doesNotThrowsError() throws {
+    let url = URL(string: "http://apple.com")
+    XCTAssertNotNil(try url.flatMap { url in
+      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
+      return url
+    })
+  }
+
+  func test_makeHTTPResponsePublisher_schemeIsHTTPS_doesNotThrowsError() throws {
+    let url = URL(string: "https://apple.com")
+    XCTAssertNotNil(try url.flatMap { url in
+      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
+      return url
+    })
+  }
+
+  func test_makeHTTPResponsePublisher_schemeIsFTP_throwsError() throws {
+    let url = URL(string: "ftp://apple.com")
+    XCTAssertNotNil(try url.flatMap { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeHTTPResponsePublisher(for: url),
+        "Error has code for .schemeNotHTTPBased",
         errorHandler)
       return url
     })

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -43,11 +43,11 @@ final class HTTPResponseFactoryTests: XCTestCase {
     XCTAssertNotNil(try url.flatMap { url in
       let errorHandler: (Error) -> Void = {
         let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotSecure.rawValue)
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: url),
-        "Error has code for .schemeNotSecure",
+        "Error has code for .schemeNotHTTPS",
         errorHandler)
       return url
     })
@@ -58,11 +58,11 @@ final class HTTPResponseFactoryTests: XCTestCase {
     XCTAssertNotNil(try url.flatMap { url in
       let errorHandler: (Error) -> Void = {
         let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotSecure.rawValue)
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: url),
-        "Error has code for .schemeNotSecure",
+        "Error has code for .schemeNotHTTPS",
         errorHandler)
       return url
     })


### PR DESCRIPTION
Now there are ways to get back a `HTTPResponse` from a URL that has either a "http" or "https" scheme.
While I'm here I added more tests.