### PR TITLE
Support creating publishers of `HTTPResponse` from a URL request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-You can now create a publisher for a `HTTPResponse` with a `URLRequest`, allowing you to add custom headers.
+You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers.
 
 ## 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+You can now create a publisher for a `HTTPResponse` with a `URLRequest`, allowing you to add custom headers.
+
 ## 0.0.2
 
 We [explicitly specify the platforms](https://github.com/bachand/BachandNetworking/pull/3) that we support and we [build those platforms in

--- a/Sources/BachandNetworking/HTTPResponse.swift
+++ b/Sources/BachandNetworking/HTTPResponse.swift
@@ -113,7 +113,6 @@ public func makeSecureHTTPResponsePublisher(
 ///
 /// - Returns: A type-erased publisher.
 ///
-///
 /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
 ///   other than "http" or "https" the error code is 102. If the request does not have a URL the error code is 103.
 public func makeHTTPResponsePublisher(

--- a/Sources/BachandNetworking/HTTPResponse.swift
+++ b/Sources/BachandNetworking/HTTPResponse.swift
@@ -5,8 +5,8 @@ import Foundation
 
 /// A value type representing a HTTP response.
 public struct HTTPResponse {
-  /// - Throws: An error if `urlResponse` is any type other than `HTTPURLResponse`. The error will have the domain
-  /// "HTTPResponse" and the code 100. The error is of type `NSError`.
+  /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If `urlResponse` is any type other
+  ///   than `HTTPURLResponse` the error code is 100.
   init(data: Data, urlResponse: URLResponse) throws {
     self.data = data
     guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
@@ -36,6 +36,8 @@ enum HTTPResponseError {
     case schemeNotHTTPS = 101
     /// Developer specified a URL that does not have a "http" or "https" scheme.
     case schemeNotHTTPBased = 102
+    /// Developer specified a URL request with no associated URL.
+    case requestHasNoURL = 103
   }
 }
 
@@ -47,8 +49,8 @@ enum HTTPResponseError {
 ///
 /// - Returns: A type-erased publisher.
 ///
-/// - Throws: An error if the URL has any scheme other than "https". The error will have the domain "HTTPResponse" and the code
-/// 101. The error is of type `NSError`.
+/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
+///   "https" the error code is 101.
 public func makeSecureHTTPResponsePublisher(
   for url: URL,
   on urlSession: URLSession = .shared)
@@ -67,8 +69,8 @@ public func makeSecureHTTPResponsePublisher(
 ///
 /// - Returns: A type-erased publisher.
 ///
-/// - Throws: An error if the URL has any scheme other than "http" or "https". The error will have the domain "HTTPResponse" and
-/// the code 102. The error is of type `NSError`.
+/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
+///   "http" or "https" the error code is 102.
 public func makeHTTPResponsePublisher(
   for url: URL,
   on urlSession: URLSession = .shared)
@@ -79,10 +81,63 @@ public func makeHTTPResponsePublisher(
     throw makeError(code: .schemeNotHTTPBased)
   }
 
-  let publisher = urlSession.dataTaskPublisher(for: url)
-  // Force unwrapping because the scheme is HTTPS. Apple documentation says that you will always
-  // give back a `HTTPURLResponse` if you issue a request to a URL with a HTTP scheme.
-  return publisher.map { try! HTTPResponse(data: $0, urlResponse: $1) }.eraseToAnyPublisher()
+  return urlSession.dataTaskPublisher(for: url).eraseToAnyPublisherOfHTTPResponse()
+}
+
+/// Creates a data task publisher for a URL request where the data is retrievable over HTTP. The output of that publisher is mapped to a
+/// `HTTPResponse`.
+///
+/// - Parameter urlRequest: The URL request to be made.
+/// - Parameter session: The session that will make the request.
+///
+/// - Returns: A type-erased publisher.
+///
+/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
+///   other than "https" the error code is 101. If the request does not have a URL the error code is 103.
+public func makeSecureHTTPResponsePublisher(
+  for urlRequest: URLRequest,
+  on urlSession: URLSession = .shared)
+  throws
+  -> AnyPublisher<HTTPResponse, URLError>
+{
+  guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
+  guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
+  return try makeHTTPResponsePublisher(for: urlRequest, on: urlSession)
+}
+
+/// Creates a data task publisher for a URL request where the data is retrievable over HTTP or HTTPS. The output of that publisher is
+/// mapped to a `HTTPResponse`.
+///
+/// - Parameter urlRequest: The URL reques to be made.
+/// - Parameter session: The session that will make the request.
+///
+/// - Returns: A type-erased publisher.
+///
+///
+/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
+///   other than "http" or "https" the error code is 102. If the request does not have a URL the error code is 103.
+public func makeHTTPResponsePublisher(
+  for urlRequest: URLRequest,
+  on urlSession: URLSession = .shared)
+  throws
+  -> AnyPublisher<HTTPResponse, URLError>
+{
+  guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
+  guard let scheme = url.scheme, ["http", "https"].contains(scheme) else {
+    throw makeError(code: .schemeNotHTTPBased)
+  }
+
+  return urlSession.dataTaskPublisher(for: urlRequest).eraseToAnyPublisherOfHTTPResponse()
+}
+
+extension URLSession.DataTaskPublisher {
+
+  fileprivate func eraseToAnyPublisherOfHTTPResponse() -> AnyPublisher<HTTPResponse, URLError> {
+    // Force unwrapping because we've previously verified that the scheme is HTTP-based. Apple
+    // documentation says that you will alway get back a `HTTPURLResponse` if you issue a request to
+    // a URL with an HTTP-based scheme.
+    map { try! HTTPResponse(data: $0, urlResponse: $1) }.eraseToAnyPublisher()
+  }
 }
 
 private func makeError(code: HTTPResponseError.Code) -> Error {

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -64,7 +64,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: url),
-        "Error has code for .schemeNotHTTPS",
+        "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
   }
@@ -77,7 +77,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: url),
-        "Error has code for .schemeNotHTTPS",
+        "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
   }
@@ -102,7 +102,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeHTTPResponsePublisher(for: url),
-        "Error has code for .schemeNotHTTPBased",
+        "Error should have code for .schemeNotHTTPBased",
         errorHandler)
     }
   }
@@ -121,7 +121,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)),
-        "Error has code for .schemeNotHTTPS",
+        "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
   }
@@ -134,7 +134,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)),
-        "Error has code for .schemeNotHTTPS",
+        "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
   }
@@ -149,7 +149,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeSecureHTTPResponsePublisher(for: urlRequest),
-        "Error has code for .requestHasNoURL",
+        "Error should have code for .requestHasNoURL",
         errorHandler)
     }
   }
@@ -174,7 +174,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeHTTPResponsePublisher(for: URLRequest(url: url)),
-        "Error has code for .schemeNotHTTPBased",
+        "Error should have code for .schemeNotHTTPBased",
         errorHandler)
     }
   }
@@ -189,7 +189,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeHTTPResponsePublisher(for: urlRequest),
-        "Error has code for .requestHasNoURL",
+        "Error should have code for .requestHasNoURL",
         errorHandler)
     }
   }

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -194,9 +194,8 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
   }
 
-  // Attempts to unwrap a string representing a URL, invoking the provided closure if the unwrapping
-  // is succesful. Fires an XCTest assertion on the calling line of code if the string does not
-  // represent a valid URL.
+  /// Attempts to create a URL from a string representing a URL, invoking the provided closure if the URL is non-`nil`. Fires an
+  /// XCTest assertion on the calling line of code if the string does not represent a valid URL.
   private func safelyUnwrapURL(
     string: String,
     file: StaticString = #filePath,

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -50,7 +50,7 @@ final class HTTPResponseTests: XCTestCase {
 
 final class HTTPResponseFactoryTests: XCTestCase {
 
-  func test_makeSecureHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowsError() throws {
+  func test_makeSecureHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
       XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: url))
     }
@@ -82,13 +82,13 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
   }
 
-  func test_makeHTTPResponsePublisherForURL_schemeIsHTTP_doesNotThrowsError() throws {
+  func test_makeHTTPResponsePublisherForURL_schemeIsHTTP_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "http://apple.com") { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
     }
   }
 
-  func test_makeHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowsError() throws {
+  func test_makeHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
     }
@@ -107,7 +107,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
   }
 
-  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowsError() throws {
+  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
       XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)))
     }
@@ -154,13 +154,13 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
   }
 
-  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTP_doesNotThrowsError() throws {
+  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTP_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "http://apple.com") { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: URLRequest(url: url)))
     }
   }
 
-  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowsError() throws {
+  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: URLRequest(url: url)))
     }

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -30,7 +30,7 @@ final class HTTPResponseTests: XCTestCase {
 
 final class HTTPResponseFactoryTests: XCTestCase {
 
-  func test_makeSecureHTTPResponsePublisher_schemeIsHTTPS_doesNotThrowsError() throws {
+  func test_makeSecureHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowsError() throws {
     let url = URL(string: "https://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: url))
@@ -38,7 +38,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     })
   }
 
-  func test_makeSecureHTTPResponsePublisher_schemeIsHTTP_throwsError() throws {
+  func test_makeSecureHTTPResponsePublisherForURL_schemeIsHTTP_throwsError() throws {
     let url = URL(string: "http://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       let errorHandler: (Error) -> Void = {
@@ -53,7 +53,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     })
   }
 
-  func test_makeSecureHTTPResponsePublisher_schemeIsFTP_throwsError() throws {
+  func test_makeSecureHTTPResponsePublisherForURL_schemeIsFTP_throwsError() throws {
     let url = URL(string: "ftp://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       let errorHandler: (Error) -> Void = {
@@ -68,7 +68,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     })
   }
 
-  func test_makeHTTPResponsePublisher_schemeIsHTTP_doesNotThrowsError() throws {
+  func test_makeHTTPResponsePublisherForURL_schemeIsHTTP_doesNotThrowsError() throws {
     let url = URL(string: "http://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
@@ -76,7 +76,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     })
   }
 
-  func test_makeHTTPResponsePublisher_schemeIsHTTPS_doesNotThrowsError() throws {
+  func test_makeHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowsError() throws {
     let url = URL(string: "https://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
@@ -84,7 +84,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     })
   }
 
-  func test_makeHTTPResponsePublisher_schemeIsFTP_throwsError() throws {
+  func test_makeHTTPResponsePublisherForURL_schemeIsFTP_throwsError() throws {
     let url = URL(string: "ftp://apple.com")
     XCTAssertNotNil(try url.flatMap { url in
       let errorHandler: (Error) -> Void = {

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -107,6 +107,93 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
   }
 
+  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowsError() throws {
+    try safelyUnwrapURL(string: "https://apple.com") { url in
+      XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)))
+    }
+  }
+
+  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsHTTP_throwsError() throws {
+    try safelyUnwrapURL(string: "http://apple.com") { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)),
+        "Error has code for .schemeNotHTTPS",
+        errorHandler)
+    }
+  }
+
+  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsFTP_throwsError() throws {
+    try safelyUnwrapURL(string: "ftp://apple.com") { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)),
+        "Error has code for .schemeNotHTTPS",
+        errorHandler)
+    }
+  }
+
+  func test_makeSecureHTTPResponsePublisherForURLRequest_urlIsNil_throwsError() throws {
+    try safelyUnwrapURL(string: "url/that/will/be/removed") { url in
+      var urlRequest = URLRequest(url: url)
+      urlRequest.url = nil
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.requestHasNoURL.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeSecureHTTPResponsePublisher(for: urlRequest),
+        "Error has code for .requestHasNoURL",
+        errorHandler)
+    }
+  }
+
+  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTP_doesNotThrowsError() throws {
+    try safelyUnwrapURL(string: "http://apple.com") { url in
+      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: URLRequest(url: url)))
+    }
+  }
+
+  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowsError() throws {
+    try safelyUnwrapURL(string: "https://apple.com") { url in
+      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: URLRequest(url: url)))
+    }
+  }
+
+  func test_makeHTTPResponsePublisherForURLRequest_schemeIsFTP_throwsError() throws {
+    try safelyUnwrapURL(string: "ftp://apple.com") { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeHTTPResponsePublisher(for: URLRequest(url: url)),
+        "Error has code for .schemeNotHTTPBased",
+        errorHandler)
+    }
+  }
+
+  func test_makeHTTPResponsePublisherForURLRequest_urlIsNil_throwsError() throws {
+    try safelyUnwrapURL(string: "url/that/will/be/removed") { url in
+      var urlRequest = URLRequest(url: url)
+      urlRequest.url = nil
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.requestHasNoURL.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeHTTPResponsePublisher(for: urlRequest),
+        "Error has code for .requestHasNoURL",
+        errorHandler)
+    }
+  }
+
   // Attempts to unwrap a string representing a URL, invoking the provided closure if the unwrapping
   // is succesful. Fires an XCTest assertion on the calling line of code if the string does not
   // represent a valid URL.
@@ -123,7 +210,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
     XCTAssertNotNil(
       mappedURL,
-      "String \"\(string)\" does not represent a valid URL",
+      "String \"\(string)\" must represent a valid URL",
       file: file,
       line: line)
   }

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -4,7 +4,11 @@ import XCTest
 
 @testable import BachandNetworking
 
+// MARK: - HTTPResponseTests
+
 final class HTTPResponseTests: XCTestCase {
+
+  // MARK: Internal
 
   func test_init_urlResponseIsNotHTTP_throwsError() {
     let errorHandler: (Error) -> Void = {
@@ -26,7 +30,23 @@ final class HTTPResponseTests: XCTestCase {
     let sut = try HTTPResponse(data: .init(), urlResponse: urlResponse)
     XCTAssertEqual(sut.statusCode, 10)
   }
+
+  // MARK: Private
+
+  private func makeStubHTTPURLResponse(
+    url: URL = URL(string: "/resource")!,
+    statusCode: Int)
+    -> HTTPURLResponse
+  {
+    HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil)!
+  }
 }
+
+// MARK: - HTTPResponseFactoryTests
 
 final class HTTPResponseFactoryTests: XCTestCase {
 
@@ -98,16 +118,4 @@ final class HTTPResponseFactoryTests: XCTestCase {
       return url
     })
   }
-}
-
-private func makeStubHTTPURLResponse(
-  url: URL = URL(string: "/resource")!,
-  statusCode: Int)
-  -> HTTPURLResponse
-{
-  HTTPURLResponse(
-    url: url,
-    statusCode: statusCode,
-    httpVersion: nil,
-    headerFields: nil)!
 }


### PR DESCRIPTION
We remove boilerplate in tests by adding a helper function to turn a string into a URL without a force unwrap. We make documentation comments easier to read. And we add two new API for creating a publisher of an `HTTPResponse` with a URL request in addition to a URL.