### PR TITLE
Update to new simulators for CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,10 +19,10 @@ jobs:
       run: swift test -v
 
     - name: Build for iOS
-      run: xcodebuild -scheme BachandNetworking -destination 'platform=iOS Simulator,OS=13.6,name=iPhone 11 Pro'
+      run: xcodebuild -scheme BachandNetworking -destination 'platform=iOS Simulator,OS=14.2,name=iPhone 12 Pro'
     - name: Build for macOS
       run: xcodebuild -scheme BachandNetworking -destination 'platform=macOS,variant=Mac Catalyst'
     - name: Build for tvOS
-      run: xcodebuild -scheme BachandNetworking -destination 'platform=tvOS Simulator,OS=13.4,name=Apple TV 4K'
+      run: xcodebuild -scheme BachandNetworking -destination 'platform=tvOS Simulator,OS=14.2,name=Apple TV 4K'
     - name: Build for watchOS
       run: echo 'Do nothing until watchOS supports XCTest'


### PR DESCRIPTION
I wonder if there is a way to do this where we don't need to specify the version. That is something I can explore in the future.