### PR TITLE
Swap names for methods to create publishers of `HTTPResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers.
+You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers. The `makeSecureHTTPResponsePublisher(for:in:)` methods have been renamed to `makeHTTPResponsePublisher(for:in:)` and the `makeHTTPResponsePublisher(for:in:)` have been renamed to `makeInsecureHTTPResponsePublisher(for:in:)` to reflect the fact that developers should prefer HTTPS.
 
 ## 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers. The `makeSecureHTTPResponsePublisher(for:in:)` methods have been renamed to `makeHTTPResponsePublisher(for:in:)` and the `makeHTTPResponsePublisher(for:in:)` have been renamed to `makeInsecureHTTPResponsePublisher(for:in:)` to reflect the fact that developers should prefer HTTPS.
+You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers. The `makeSecureHTTPResponsePublisher(for:in:)` functions have been renamed to `makeHTTPResponsePublisher(for:in:)` and the `makeHTTPResponsePublisher(for:in:)` functions have been renamed to `makeInsecureHTTPResponsePublisher(for:in:)` to reflect the fact that developers should prefer HTTPS.
 
 ## 0.0.2
 

--- a/Sources/BachandNetworking/HTTPResponse.swift
+++ b/Sources/BachandNetworking/HTTPResponse.swift
@@ -41,8 +41,7 @@ enum HTTPResponseError {
   }
 }
 
-/// Creates a data task publisher for a URL where the data is retrievable over HTTP. The output of that publisher is mapped to a
-/// `HTTPResponse`.
+/// Creates a data task publisher for a URL with the HTTPS scheme. The output of that publisher is mapped to an `HTTPResponse`.
 ///
 /// - Parameter url: The URL to which we should make a request.
 /// - Parameter session: The session that will make the request.
@@ -51,18 +50,21 @@ enum HTTPResponseError {
 ///
 /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
 ///   "https" the error code is 101.
-public func makeSecureHTTPResponsePublisher(
+public func makeHTTPResponsePublisher(
   for url: URL,
   on urlSession: URLSession = .shared)
   throws
   -> AnyPublisher<HTTPResponse, URLError>
 {
   guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
-  return try makeHTTPResponsePublisher(for: url, on: urlSession)
+  return try makeInsecureHTTPResponsePublisher(for: url, on: urlSession)
 }
 
-/// Creates a data task publisher for a URL where the data is retrievable over HTTP or HTTPS. The output of that publisher is mapped to
-/// a `HTTPResponse`.
+/// Creates a data task publisher for a URL with the HTTP or HTTPS scheme. The output of that publisher is mapped to an
+/// `HTTPResponse`.
+///
+/// - Important: HTTP makes it easier for user data to be snooped by someone else. Prefer using
+///   `makeHTTPResponsePublisher(for:on:)` with an HTTPS URL.
 ///
 /// - Parameter url: The URL to which we should make a request.
 /// - Parameter session: The session that will make the request.
@@ -71,7 +73,7 @@ public func makeSecureHTTPResponsePublisher(
 ///
 /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
 ///   "http" or "https" the error code is 102.
-public func makeHTTPResponsePublisher(
+public func makeInsecureHTTPResponsePublisher(
   for url: URL,
   on urlSession: URLSession = .shared)
   throws
@@ -84,7 +86,7 @@ public func makeHTTPResponsePublisher(
   return urlSession.dataTaskPublisher(for: url).eraseToAnyPublisherOfHTTPResponse()
 }
 
-/// Creates a data task publisher for a URL request where the data is retrievable over HTTP. The output of that publisher is mapped to a
+/// Creates a data task publisher for a URL request with the HTTPS scheme. The output of that publisher is mapped to an
 /// `HTTPResponse`.
 ///
 /// - Parameter urlRequest: The URL request to be made.
@@ -94,7 +96,7 @@ public func makeHTTPResponsePublisher(
 ///
 /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
 ///   other than "https" the error code is 101. If the request does not have a URL the error code is 103.
-public func makeSecureHTTPResponsePublisher(
+public func makeHTTPResponsePublisher(
   for urlRequest: URLRequest,
   on urlSession: URLSession = .shared)
   throws
@@ -102,11 +104,14 @@ public func makeSecureHTTPResponsePublisher(
 {
   guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
   guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
-  return try makeHTTPResponsePublisher(for: urlRequest, on: urlSession)
+  return try makeInsecureHTTPResponsePublisher(for: urlRequest, on: urlSession)
 }
 
-/// Creates a data task publisher for a URL request where the data is retrievable over HTTP or HTTPS. The output of that publisher is
-/// mapped to a `HTTPResponse`.
+/// Creates a data task publisher for a URL request with the HTTP or HTTPS scheme. The output of that publisher is mapped to an
+/// `HTTPResponse`.
+///
+/// - Important: HTTP makes it easier for user data to be snooped by someone else. Prefer using
+///   `makeHTTPResponsePublisher(for:on:)` with an HTTPS URL.
 ///
 /// - Parameter urlRequest: The URL reques to be made.
 /// - Parameter session: The session that will make the request.
@@ -115,7 +120,7 @@ public func makeSecureHTTPResponsePublisher(
 ///
 /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
 ///   other than "http" or "https" the error code is 102. If the request does not have a URL the error code is 103.
-public func makeHTTPResponsePublisher(
+public func makeInsecureHTTPResponsePublisher(
   for urlRequest: URLRequest,
   on urlSession: URLSession = .shared)
   throws

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -50,47 +50,22 @@ final class HTTPResponseTests: XCTestCase {
 
 final class HTTPResponseFactoryTests: XCTestCase {
 
-  func test_makeSecureHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
-    try safelyUnwrapURL(string: "https://apple.com") { url in
-      XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: url))
-    }
-  }
-
-  func test_makeSecureHTTPResponsePublisherForURL_schemeIsHTTP_throwsError() throws {
-    try safelyUnwrapURL(string: "http://apple.com") { url in
-      let errorHandler: (Error) -> Void = {
-        let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
-      }
-      XCTAssertThrowsError(
-        try makeSecureHTTPResponsePublisher(for: url),
-        "Error should have code for .schemeNotHTTPS",
-        errorHandler)
-    }
-  }
-
-  func test_makeSecureHTTPResponsePublisherForURL_schemeIsFTP_throwsError() throws {
-    try safelyUnwrapURL(string: "ftp://apple.com") { url in
-      let errorHandler: (Error) -> Void = {
-        let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
-      }
-      XCTAssertThrowsError(
-        try makeSecureHTTPResponsePublisher(for: url),
-        "Error should have code for .schemeNotHTTPS",
-        errorHandler)
-    }
-  }
-
-  func test_makeHTTPResponsePublisherForURL_schemeIsHTTP_doesNotThrowError() throws {
-    try safelyUnwrapURL(string: "http://apple.com") { url in
-      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
-    }
-  }
-
   func test_makeHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
       XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
+    }
+  }
+
+  func test_makeHTTPResponsePublisherForURL_schemeIsHTTP_throwsError() throws {
+    try safelyUnwrapURL(string: "http://apple.com") { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeHTTPResponsePublisher(for: url),
+        "Error should have code for .schemeNotHTTPS",
+        errorHandler)
     }
   }
 
@@ -98,65 +73,37 @@ final class HTTPResponseFactoryTests: XCTestCase {
     try safelyUnwrapURL(string: "ftp://apple.com") { url in
       let errorHandler: (Error) -> Void = {
         let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
         try makeHTTPResponsePublisher(for: url),
-        "Error should have code for .schemeNotHTTPBased",
-        errorHandler)
-    }
-  }
-
-  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowError() throws {
-    try safelyUnwrapURL(string: "https://apple.com") { url in
-      XCTAssertNoThrow(try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)))
-    }
-  }
-
-  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsHTTP_throwsError() throws {
-    try safelyUnwrapURL(string: "http://apple.com") { url in
-      let errorHandler: (Error) -> Void = {
-        let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
-      }
-      XCTAssertThrowsError(
-        try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)),
         "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
   }
 
-  func test_makeSecureHTTPResponsePublisherForURLRequest_schemeIsFTP_throwsError() throws {
+  func test_makeInsecureHTTPResponsePublisherForURL_schemeIsHTTP_doesNotThrowError() throws {
+    try safelyUnwrapURL(string: "http://apple.com") { url in
+      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: url))
+    }
+  }
+
+  func test_makeInsecureHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
+    try safelyUnwrapURL(string: "https://apple.com") { url in
+      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: url))
+    }
+  }
+
+  func test_makeInsecureHTTPResponsePublisherForURL_schemeIsFTP_throwsError() throws {
     try safelyUnwrapURL(string: "ftp://apple.com") { url in
       let errorHandler: (Error) -> Void = {
         let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
       }
       XCTAssertThrowsError(
-        try makeSecureHTTPResponsePublisher(for: URLRequest(url: url)),
-        "Error should have code for .schemeNotHTTPS",
+        try makeInsecureHTTPResponsePublisher(for: url),
+        "Error should have code for .schemeNotHTTPBased",
         errorHandler)
-    }
-  }
-
-  func test_makeSecureHTTPResponsePublisherForURLRequest_urlIsNil_throwsError() throws {
-    try safelyUnwrapURL(string: "url/that/will/be/removed") { url in
-      var urlRequest = URLRequest(url: url)
-      urlRequest.url = nil
-      let errorHandler: (Error) -> Void = {
-        let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.requestHasNoURL.rawValue)
-      }
-      XCTAssertThrowsError(
-        try makeSecureHTTPResponsePublisher(for: urlRequest),
-        "Error should have code for .requestHasNoURL",
-        errorHandler)
-    }
-  }
-
-  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTP_doesNotThrowError() throws {
-    try safelyUnwrapURL(string: "http://apple.com") { url in
-      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: URLRequest(url: url)))
     }
   }
 
@@ -166,15 +113,28 @@ final class HTTPResponseFactoryTests: XCTestCase {
     }
   }
 
+  func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTP_throwsError() throws {
+    try safelyUnwrapURL(string: "http://apple.com") { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeHTTPResponsePublisher(for: URLRequest(url: url)),
+        "Error should have code for .schemeNotHTTPS",
+        errorHandler)
+    }
+  }
+
   func test_makeHTTPResponsePublisherForURLRequest_schemeIsFTP_throwsError() throws {
     try safelyUnwrapURL(string: "ftp://apple.com") { url in
       let errorHandler: (Error) -> Void = {
         let nsError = $0 as NSError
-        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
         try makeHTTPResponsePublisher(for: URLRequest(url: url)),
-        "Error should have code for .schemeNotHTTPBased",
+        "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
   }
@@ -189,6 +149,46 @@ final class HTTPResponseFactoryTests: XCTestCase {
       }
       XCTAssertThrowsError(
         try makeHTTPResponsePublisher(for: urlRequest),
+        "Error should have code for .requestHasNoURL",
+        errorHandler)
+    }
+  }
+
+  func test_makeInsecureHTTPResponsePublisherForURLRequest_schemeIsHTTP_doesNotThrowError() throws {
+    try safelyUnwrapURL(string: "http://apple.com") { url in
+      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)))
+    }
+  }
+
+  func test_makeInsecureHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowError() throws {
+    try safelyUnwrapURL(string: "https://apple.com") { url in
+      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)))
+    }
+  }
+
+  func test_makeInsecureHTTPResponsePublisherForURLRequest_schemeIsFTP_throwsError() throws {
+    try safelyUnwrapURL(string: "ftp://apple.com") { url in
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)),
+        "Error should have code for .schemeNotHTTPBased",
+        errorHandler)
+    }
+  }
+
+  func test_makeInsecureHTTPResponsePublisherForURLRequest_urlIsNil_throwsError() throws {
+    try safelyUnwrapURL(string: "url/that/will/be/removed") { url in
+      var urlRequest = URLRequest(url: url)
+      urlRequest.url = nil
+      let errorHandler: (Error) -> Void = {
+        let nsError = $0 as NSError
+        XCTAssertEqual(nsError.code, HTTPResponseError.Code.requestHasNoURL.rawValue)
+      }
+      XCTAssertThrowsError(
+        try makeInsecureHTTPResponsePublisher(for: urlRequest),
         "Error should have code for .requestHasNoURL",
         errorHandler)
     }


### PR DESCRIPTION
We will use simpler names for the preferred methods. We also improve the documentation comments.