### PR TITLE
Namespace methods to make `HTTPResponse` publisher within `URLSession`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next version
 
-You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers. The `makeSecureHTTPResponsePublisher(for:in:)` functions have been renamed to `makeHTTPResponsePublisher(for:in:)` and the `makeHTTPResponsePublisher(for:in:)` functions have been renamed to `makeInsecureHTTPResponsePublisher(for:in:)` to reflect the fact that developers should prefer HTTPS.
+You can now create a publisher for an `HTTPResponse` with a `URLRequest`, allowing you to add custom headers.
+
+The `makeSecureHTTPResponsePublisher(for:in:)` functions have been renamed to `makeHTTPResponsePublisher(for:in:)` and the `makeHTTPResponsePublisher(for:in:)` functions have been renamed to `makeInsecureHTTPResponsePublisher(for:in:)` to reflect the fact that developers should prefer HTTPS. We've also namespaced the methods to make an `HTTPSResponse` publisher within `URLSession` since that style is generally preferred to free functions.
 
 ## 0.0.2
 

--- a/Sources/BachandNetworking/HTTPResponse.swift
+++ b/Sources/BachandNetworking/HTTPResponse.swift
@@ -3,6 +3,8 @@
 import Combine
 import Foundation
 
+// MARK: - HTTPResponse
+
 /// A value type representing a HTTP response.
 public struct HTTPResponse {
   /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If `urlResponse` is any type other
@@ -23,6 +25,8 @@ public struct HTTPResponse {
   public var statusCode: Int { response.statusCode }
 }
 
+// MARK: - HTTPResponseError
+
 /// A namespace for values associated with any error encountered during the process of getting a `HTTPResponse`.
 enum HTTPResponseError {
   /// The domain of errors.
@@ -41,98 +45,105 @@ enum HTTPResponseError {
   }
 }
 
-/// Creates a data task publisher for a URL with the HTTPS scheme. The output of that publisher is mapped to an `HTTPResponse`.
-///
-/// - Parameter url: The URL to which we should make a request.
-/// - Parameter session: The session that will make the request.
-///
-/// - Returns: A type-erased publisher.
-///
-/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
-///   "https" the error code is 101.
-public func makeHTTPResponsePublisher(
-  for url: URL,
-  on urlSession: URLSession = .shared)
-  throws
-  -> AnyPublisher<HTTPResponse, URLError>
-{
-  guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
-  return try makeInsecureHTTPResponsePublisher(for: url, on: urlSession)
-}
+// MARK: - URLSession
 
-/// Creates a data task publisher for a URL with the HTTP or HTTPS scheme. The output of that publisher is mapped to an
-/// `HTTPResponse`.
-///
-/// - Important: HTTP makes it easier for user data to be snooped by someone else. Prefer using
-///   `makeHTTPResponsePublisher(for:on:)` with an HTTPS URL.
-///
-/// - Parameter url: The URL to which we should make a request.
-/// - Parameter session: The session that will make the request.
-///
-/// - Returns: A type-erased publisher.
-///
-/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
-///   "http" or "https" the error code is 102.
-public func makeInsecureHTTPResponsePublisher(
-  for url: URL,
-  on urlSession: URLSession = .shared)
+extension URLSession {
+
+  /// Creates a data task publisher for a URL with the HTTPS scheme. The output of that publisher is mapped to an `HTTPResponse`.
+  ///
+  /// - Parameter url: The URL to which we should make a request.
+  /// - Parameter session: The session that will make the request.
+  ///
+  /// - Returns: A type-erased publisher.
+  ///
+  /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
+  ///   "https" the error code is 101.
+  public static func makeHTTPResponsePublisher(
+    for url: URL,
+    on urlSession: URLSession = .shared)
   throws
   -> AnyPublisher<HTTPResponse, URLError>
-{
-  guard let scheme = url.scheme, ["http", "https"].contains(scheme) else {
-    throw makeError(code: .schemeNotHTTPBased)
+  {
+    guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
+    return try makeInsecureHTTPResponsePublisher(for: url, on: urlSession)
   }
 
-  return urlSession.dataTaskPublisher(for: url).eraseToAnyPublisherOfHTTPResponse()
-}
-
-/// Creates a data task publisher for a URL request with the HTTPS scheme. The output of that publisher is mapped to an
-/// `HTTPResponse`.
-///
-/// - Parameter urlRequest: The URL request to be made.
-/// - Parameter session: The session that will make the request.
-///
-/// - Returns: A type-erased publisher.
-///
-/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
-///   other than "https" the error code is 101. If the request does not have a URL the error code is 103.
-public func makeHTTPResponsePublisher(
-  for urlRequest: URLRequest,
-  on urlSession: URLSession = .shared)
+  /// Creates a data task publisher for a URL with the HTTP or HTTPS scheme. The output of that publisher is mapped to an
+  /// `HTTPResponse`.
+  ///
+  /// - Important: HTTP makes it easier for user data to be snooped by someone else. Prefer using
+  ///   `makeHTTPResponsePublisher(for:on:)` with an HTTPS URL.
+  ///
+  /// - Parameter url: The URL to which we should make a request.
+  /// - Parameter session: The session that will make the request.
+  ///
+  /// - Returns: A type-erased publisher.
+  ///
+  /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the URL has any scheme other than
+  ///   "http" or "https" the error code is 102.
+  public static func makeInsecureHTTPResponsePublisher(
+    for url: URL,
+    on urlSession: URLSession = .shared)
   throws
   -> AnyPublisher<HTTPResponse, URLError>
-{
-  guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
-  guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
-  return try makeInsecureHTTPResponsePublisher(for: urlRequest, on: urlSession)
-}
+  {
+    guard let scheme = url.scheme, ["http", "https"].contains(scheme) else {
+      throw makeError(code: .schemeNotHTTPBased)
+    }
 
-/// Creates a data task publisher for a URL request with the HTTP or HTTPS scheme. The output of that publisher is mapped to an
-/// `HTTPResponse`.
-///
-/// - Important: HTTP makes it easier for user data to be snooped by someone else. Prefer using
-///   `makeHTTPResponsePublisher(for:on:)` with an HTTPS URL.
-///
-/// - Parameter urlRequest: The URL reques to be made.
-/// - Parameter session: The session that will make the request.
-///
-/// - Returns: A type-erased publisher.
-///
-/// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
-///   other than "http" or "https" the error code is 102. If the request does not have a URL the error code is 103.
-public func makeInsecureHTTPResponsePublisher(
-  for urlRequest: URLRequest,
-  on urlSession: URLSession = .shared)
-  throws
-  -> AnyPublisher<HTTPResponse, URLError>
-{
-  guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
-  guard let scheme = url.scheme, ["http", "https"].contains(scheme) else {
-    throw makeError(code: .schemeNotHTTPBased)
+    return urlSession.dataTaskPublisher(for: url).eraseToAnyPublisherOfHTTPResponse()
   }
 
-  return urlSession.dataTaskPublisher(for: urlRequest).eraseToAnyPublisherOfHTTPResponse()
+  /// Creates a data task publisher for a URL request with the HTTPS scheme. The output of that publisher is mapped to an
+  /// `HTTPResponse`.
+  ///
+  /// - Parameter urlRequest: The URL request to be made.
+  /// - Parameter session: The session that will make the request.
+  ///
+  /// - Returns: A type-erased publisher.
+  ///
+  /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
+  ///   other than "https" the error code is 101. If the request does not have a URL the error code is 103.
+  public static func makeHTTPResponsePublisher(
+    for urlRequest: URLRequest,
+    on urlSession: URLSession = .shared)
+  throws
+  -> AnyPublisher<HTTPResponse, URLError>
+  {
+    guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
+    guard let scheme = url.scheme, scheme == "https" else { throw makeError(code: .schemeNotHTTPS) }
+    return try makeInsecureHTTPResponsePublisher(for: urlRequest, on: urlSession)
+  }
+
+  /// Creates a data task publisher for a URL request with the HTTP or HTTPS scheme. The output of that publisher is mapped to an
+  /// `HTTPResponse`.
+  ///
+  /// - Important: HTTP makes it easier for user data to be snooped by someone else. Prefer using
+  ///   `makeHTTPResponsePublisher(for:on:)` with an HTTPS URL.
+  ///
+  /// - Parameter urlRequest: The URL reques to be made.
+  /// - Parameter session: The session that will make the request.
+  ///
+  /// - Returns: A type-erased publisher.
+  ///
+  /// - Throws: All errors are of type `NSError` and will have the domain "HTTPResponse". If the request's URL has any scheme
+  ///   other than "http" or "https" the error code is 102. If the request does not have a URL the error code is 103.
+  public static func makeInsecureHTTPResponsePublisher(
+    for urlRequest: URLRequest,
+    on urlSession: URLSession = .shared)
+  throws
+  -> AnyPublisher<HTTPResponse, URLError>
+  {
+    guard let url = urlRequest.url else { throw makeError(code: .requestHasNoURL) }
+    guard let scheme = url.scheme, ["http", "https"].contains(scheme) else {
+      throw makeError(code: .schemeNotHTTPBased)
+    }
+
+    return urlSession.dataTaskPublisher(for: urlRequest).eraseToAnyPublisherOfHTTPResponse()
+  }
 }
+
+// MARK: - URLSession.DataTaskPublisher
 
 extension URLSession.DataTaskPublisher {
 
@@ -143,6 +154,8 @@ extension URLSession.DataTaskPublisher {
     map { try! HTTPResponse(data: $0, urlResponse: $1) }.eraseToAnyPublisher()
   }
 }
+
+// MARK: Free functions
 
 private func makeError(code: HTTPResponseError.Code) -> Error {
   NSError(domain: HTTPResponseError.errorDomain, code: code.rawValue)

--- a/Tests/BachandNetworkingTests/HTTPResponseTests.swift
+++ b/Tests/BachandNetworkingTests/HTTPResponseTests.swift
@@ -1,5 +1,6 @@
 //  Created by Michael Bachand on 8/21/20.
 
+import Foundation
 import XCTest
 
 @testable import BachandNetworking
@@ -52,7 +53,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
 
   func test_makeHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
-      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: url))
+      XCTAssertNoThrow(try URLSession.makeHTTPResponsePublisher(for: url))
     }
   }
 
@@ -63,7 +64,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
-        try makeHTTPResponsePublisher(for: url),
+        try URLSession.makeHTTPResponsePublisher(for: url),
         "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
@@ -76,7 +77,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
-        try makeHTTPResponsePublisher(for: url),
+        try URLSession.makeHTTPResponsePublisher(for: url),
         "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
@@ -84,13 +85,13 @@ final class HTTPResponseFactoryTests: XCTestCase {
 
   func test_makeInsecureHTTPResponsePublisherForURL_schemeIsHTTP_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "http://apple.com") { url in
-      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: url))
+      XCTAssertNoThrow(try URLSession.makeInsecureHTTPResponsePublisher(for: url))
     }
   }
 
   func test_makeInsecureHTTPResponsePublisherForURL_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
-      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: url))
+      XCTAssertNoThrow(try URLSession.makeInsecureHTTPResponsePublisher(for: url))
     }
   }
 
@@ -101,7 +102,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
       }
       XCTAssertThrowsError(
-        try makeInsecureHTTPResponsePublisher(for: url),
+        try URLSession.makeInsecureHTTPResponsePublisher(for: url),
         "Error should have code for .schemeNotHTTPBased",
         errorHandler)
     }
@@ -109,7 +110,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
 
   func test_makeHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
-      XCTAssertNoThrow(try makeHTTPResponsePublisher(for: URLRequest(url: url)))
+      XCTAssertNoThrow(try URLSession.makeHTTPResponsePublisher(for: URLRequest(url: url)))
     }
   }
 
@@ -120,7 +121,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
-        try makeHTTPResponsePublisher(for: URLRequest(url: url)),
+        try URLSession.makeHTTPResponsePublisher(for: URLRequest(url: url)),
         "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
@@ -133,7 +134,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPS.rawValue)
       }
       XCTAssertThrowsError(
-        try makeHTTPResponsePublisher(for: URLRequest(url: url)),
+        try URLSession.makeHTTPResponsePublisher(for: URLRequest(url: url)),
         "Error should have code for .schemeNotHTTPS",
         errorHandler)
     }
@@ -148,7 +149,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.requestHasNoURL.rawValue)
       }
       XCTAssertThrowsError(
-        try makeHTTPResponsePublisher(for: urlRequest),
+        try URLSession.makeHTTPResponsePublisher(for: urlRequest),
         "Error should have code for .requestHasNoURL",
         errorHandler)
     }
@@ -156,13 +157,13 @@ final class HTTPResponseFactoryTests: XCTestCase {
 
   func test_makeInsecureHTTPResponsePublisherForURLRequest_schemeIsHTTP_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "http://apple.com") { url in
-      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)))
+      XCTAssertNoThrow(try URLSession.makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)))
     }
   }
 
   func test_makeInsecureHTTPResponsePublisherForURLRequest_schemeIsHTTPS_doesNotThrowError() throws {
     try safelyUnwrapURL(string: "https://apple.com") { url in
-      XCTAssertNoThrow(try makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)))
+      XCTAssertNoThrow(try URLSession.makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)))
     }
   }
 
@@ -173,7 +174,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.schemeNotHTTPBased.rawValue)
       }
       XCTAssertThrowsError(
-        try makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)),
+        try URLSession.makeInsecureHTTPResponsePublisher(for: URLRequest(url: url)),
         "Error should have code for .schemeNotHTTPBased",
         errorHandler)
     }
@@ -188,7 +189,7 @@ final class HTTPResponseFactoryTests: XCTestCase {
         XCTAssertEqual(nsError.code, HTTPResponseError.Code.requestHasNoURL.rawValue)
       }
       XCTAssertThrowsError(
-        try makeInsecureHTTPResponsePublisher(for: urlRequest),
+        try URLSession.makeInsecureHTTPResponsePublisher(for: urlRequest),
         "Error should have code for .requestHasNoURL",
         errorHandler)
     }


### PR DESCRIPTION
Let's avoid free functions when we can easily and reasonably namespace the methods to make `HTTPResponse` publishers under `URLSession`.